### PR TITLE
chore(x509_certificate): Ansible 2.10 compatibility for x509_certificate

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -27,7 +27,7 @@
   register: crl_number_file
 
 - name: Check if certificate is expired
-  openssl_certificate:
+  community.crypto.x509_certificate:
     path: "{{ certificates_local_key_dir }}/{{ inventory_hostname }}.crt"
     provider: assertonly
     valid_in: 1209600


### PR DESCRIPTION
Since Ansible 2.10, `openssl_certificate` is no longer a part of Ansible. It can be obtained from the Ansible Galaxy collection `community.crypto` and is now called `x509_certificate`. Note that this change probably breaks compatibility with Ansible <= 2.8.